### PR TITLE
Add integration testing between aria-cli and aria-core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - TOX_ENV=validate-local-blueprint
   - TOX_ENV=validate-multicloud-blueprint
   - TOX_ENV=execute-local-blueprint
+  - TOX_ENV=py27-core-integration
 
 install:
   - ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,9 @@
 envlist=pep8,docs,py27,bandit-security,validate-local-blueprint,validate-multicloud-blueprint
 
 [testenv]
+passenv =
+    ARIA_CORE_REMOTE_REPO
+    ARIA_CORE_REMOTE_REPO_BRANCH
 deps =
     -rtest-requirements.txt
 whitelist_externals = git
@@ -58,3 +61,16 @@ commands =
         aria execute -b local-id -w install --task-retries 10 --task-retry-interval 10
         aria execute -b local-id -w uninstall --task-retries 10 --task-retry-interval 10
         rm -fr .tox/aria-example
+
+[testenv:py27-core-integration]
+deps =
+    {[testenv]deps}
+commands=
+    rm -fr .tox/aria-core
+    git clone --depth=50 --branch={env:ARIA_CORE_REMOTE_REPO_BRANCH:master} https://github.com/{env:ARIA_CORE_REMOTE_REPO:aria-tosca}/aria-core.git .tox/aria-core
+    # installing aria-cli
+    pip install -e .
+    # installing aria-core
+    pip install -e .tox/aria-core
+    nosetests -s -vv aria_cli/tests
+    rm -fr .tox/aria-core


### PR DESCRIPTION
new python testing job:

- py27-core-integration:
      1. Installs aria-cli
      2. Installs aria-core from origin master
      3. runs tests from aria-cli
